### PR TITLE
ci: fix puppeteer running

### DIFF
--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,5 +1,5 @@
 module.exports = {
   launch: {
-    headless: false,
+    // headless: false,
   },
 };


### PR DESCRIPTION
Use `headless` mode to make it correct in CI.